### PR TITLE
bug: 修复单张图片测试时label对应错误的问题

### DIFF
--- a/tools/batch_test.py
+++ b/tools/batch_test.py
@@ -24,7 +24,7 @@ def main():
     parser.add_argument('--show', action='store_true', help='Show image classification results')
     args = parser.parse_args()
 
-    classes_names, _ = get_info(args.classes_map)
+    classes_names, label_names = get_info(args.classes_map)
     # build the model from a config file and a checkpoint file
     model_cfg,train_pipeline,val_pipeline,data_cfg,lr_config,optimizer_cfg = file2dict(args.config)
     if args.device is not None:
@@ -43,7 +43,7 @@ def main():
             out_path = os.path.join(args.save_path,name)
         img = image_maps[name]
         # get single test results
-        result = inference_model(model, img, val_pipeline, classes_names)
+        result = inference_model(model, img, val_pipeline, classes_names,label_names)
         # put the results to img
         img_show = imshow_infos(img, result,show = False,out_file=out_path)
         

--- a/tools/single_test.py
+++ b/tools/single_test.py
@@ -21,7 +21,7 @@ def main():
         help='The path to save prediction image, default not to save.')
     args = parser.parse_args()
 
-    classes_names, _ = get_info(args.classes_map)
+    classes_names, label_names = get_info(args.classes_map)
     # build the model from a config file and a checkpoint file
     model_cfg,train_pipeline,val_pipeline,data_cfg,lr_config,optimizer_cfg = file2dict(args.config)
     if args.device is not None:
@@ -33,7 +33,7 @@ def main():
     model = init_model(model, data_cfg, device=device, mode='eval')
     
     # test a single image
-    result = inference_model(model, args.img, val_pipeline, classes_names)
+    result = inference_model(model, args.img, val_pipeline, classes_names,label_names)
     # show the results
     show_result_pyplot(model, args.img, result, out_file=args.save_path)
 

--- a/tools/video_test.py
+++ b/tools/video_test.py
@@ -24,7 +24,7 @@ def main():
     parser.add_argument('--show', action='store_true', help='Show video')
     args = parser.parse_args()
 
-    classes_names, _ = get_info(args.classes_map)
+    classes_names,label_names = get_info(args.classes_map)
     # build the model from a config file and a checkpoint file
     model_cfg,train_pipeline,val_pipeline,data_cfg,lr_config,optimizer_cfg = file2dict(args.config)
     if args.device is not None:
@@ -49,7 +49,7 @@ def main():
         if not flag:
             break
         # get single test results
-        result = inference_model(model, frame, val_pipeline, classes_names)
+        result = inference_model(model, frame, val_pipeline, classes_names,label_names)
         # put the results to img
         img = imshow_infos(frame, result,show = False)
 

--- a/utils/inference.py
+++ b/utils/inference.py
@@ -31,7 +31,7 @@ def init_model(model, data_cfg, device='cuda:0',mode='eval'):
     return model
 
 
-def inference_model(model, image, val_pipeline, classes_names):
+def inference_model(model, image, val_pipeline, classes_names,label_names):
     """Inference image(s) with the classifier.
 
     Args:
@@ -62,7 +62,7 @@ def inference_model(model, image, val_pipeline, classes_names):
         scores = model(image.to(device),return_loss=False)
         pred_score,pred_label = torch.max(scores, axis=1)
         result = {'pred_label': pred_label.item(), 'pred_score': float(pred_score)}
-    result['pred_class'] = classes_names[result['pred_label']]
+    result['pred_class'] = classes_names[label_names.index(result['pred_label'])]
     return result
 
 


### PR DESCRIPTION
一个潜在小Bug，在使用图像分类程序时，如果annoations填写顺序反向的话，在测试时可能会输出错误
如：high为2在第一行，low为0但在第三行，就会在单张图片测试时出现label和class对不上的bug

本版本已修复上述bug，批量图片测试亦可参考本代码修改